### PR TITLE
fix buffer overflow in SPI1

### DIFF
--- a/hardware/spi/spi_1.c
+++ b/hardware/spi/spi_1.c
@@ -129,8 +129,9 @@ void SPI1_FastRead2Mem( char * buffer, int Datalenght )
 #if defined(__AVR_ATmega2561__)
 	int Counter = 0;
 	char data;
-
-	while( Counter <= Datalenght )
+	
+	// 20200715 dl6lr copy length bytes from spi, fix by one error
+	while( Counter < Datalenght )
 	{
 		// warten auf fertig
 		while ( !( UCSR0A & (1<<UDRE0)) );
@@ -153,7 +154,8 @@ void SPI1_FastRead2Mem( char * buffer, int Datalenght )
 	int Counter = 0;
 	char data;
 
-	while( Counter <= Datalenght )
+	// 20200715 dl6lr copy length bytes from spi, fix by one error
+	while( Counter < Datalenght )
 	{
 		// warten auf fertig
 		while ( !( UCSR1A & (1<<UDRE1)) );

--- a/system/net/icmp.c
+++ b/system/net/icmp.c
@@ -94,7 +94,8 @@ void icmp( int packet_lenght, char *buffer)
 										ETH_packet->ETH_sourceMac[i] = mymac[i];
 									}
 									// und ab die post
-									sendEthernetframe( packet_lenght, buffer); // packet_lenght - 4 weil der Controller die checksumme selber berechnet
+									// 20200715 dl6lr comment was right, code was wrong, do not copy checksum of received frame
+									sendEthernetframe( packet_lenght - 4, buffer); // packet_lenght - 4 weil der Controller die checksumme selber berechnet
 									break;
 		case ICMP_EchoReplay:		if ( ICMP_packet->ICMP_Identifierer == 0xac1d && ICMP_Replaystate == ICMP_WaitForReplay )
 										ICMP_Replaystate = ICMP_ReplayOkay;

--- a/system/net/ip.c
+++ b/system/net/ip.c
@@ -78,8 +78,9 @@ void ip( int packet_lenght ,  char *buffer )
 											// checke mal ob dat Ã¼berhaupt fÃ¼r uns ist
 		// if ( IP_packet->IP_DestinationIP != myIP || IP_packet->IP_DestinationIP != 0xffffffff ) return;
 
-//		if ( ( IP_packet->IP_Flags_Fragmentoffset & htons( FRAGMENTOFFSET_bm ) ) == 0 )
-//		{
+		// 20200715 dl6lr just discard fragment frames, as they are not being reassembled
+		if ( ( IP_packet->IP_Flags_Fragmentoffset & htons( FRAGMENTOFFSET_bm ) ) == 0 )
+		{
 			switch ( IP_packet->IP_Protocol )
 			{
 				case 0x01:			if ( IP_packet->IP_DestinationIP != myIP ) return;
@@ -96,7 +97,7 @@ void ip( int packet_lenght ,  char *buffer )
 #endif
 				default:			break;
 			}
-//		}
+		}
 	}
 
 /* -----------------------------------------------------------------------------------------------------------*/


### PR DESCRIPTION
SPI1_FastRead2Mem copied buffer with length + 1 byte, causing havoc on the stack on frames that fit the MAX_FRAMELEN
Additionally: discard fragment frames as they are not being reassembled, fix wrong size of ICMP EchoReply